### PR TITLE
Fix readme to install grunt instead of gulp

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -9,7 +9,7 @@ In order to build assets for concrete5 you need:
 
 - [Node.js](https://nodejs.org/)
 - [npm](https://www.npmjs.com/) (may be bundled with Node.js)
-- [Grunt](https://gruntjs.com/) (install it globally with `npm --global install gulp`)
+- [Grunt](https://gruntjs.com/) (install it globally with `npm install -g grunt-cli`)
 
 Once you have installed the grunt client, you need to install the project dependencies. From inside the `build` directory launch the following command:
 ```


### PR DESCRIPTION
The readme instructions would install Gulp instead of Grunt. I've added the official Grunt documentation command for installing grunt globally instead of the gulp equivalent.